### PR TITLE
Upgrade to sbt-dotty 0.1.4

### DIFF
--- a/dotty-community-build/project/plugins.sbt
+++ b/dotty-community-build/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.3")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")


### PR DESCRIPTION
It was nice to see the assertion from #11 is working https://travis-ci.org/lampepfl/dotty-community-build/jobs/253116262#L294 The community build failed this morning because the 0.2 Dotty version was outdated.