### PR TITLE
Build a specific ref from lampepfl/dotty repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,31 @@
 [![Community Build Status](https://travis-ci.org/lampepfl/dotty-community-build.svg?branch=master)](https://travis-ci.org/lampepfl/dotty-community-build)
 
 This repository contains tests to build a corpus of Scala open sources projects
-against the latest changes in Dotty.
+against a specific version of Dotty.
 
-To run the community build on a local machine, clone the repo and execute `sbt test`.
+To run the community build on a local machine, clone the repo and execute `./run.sh`.
 
 The tests will by default run against the latest NIGHTLY build of dotty.
-You may customize the dotty version in `build.sbt`. You might need nigh to reload `sbt` for the
-change to take effect.
+You may customize the dotty bersion by passing the `DOTTY_REFERENCE` variable to `run.sh`. This
+variable is used to identify a specific revision to build, publish locally and against which the
+tests will be run. Some examples:
+
+  - Build a PR:
+    ```sh
+    DOTTY_REFERENCE="+refs/pull/3306/merge" ./run.sh
+    ```
+  - Build a tag:
+    ```sh
+    DOTTY_REFERENCE="0.3.0-RC2" ./run.sh
+    ```
+  - Build a specific commit:
+    ```sh
+    DOTTY_REFERENCE="deadbeef" ./run.sh
+    ```
+  - Build using the latest nightly:
+    ```sh
+    ./run.sh
+    ```
 
 ## Adding your project
 To add your project to the community build you can follow these steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,11 @@
+lazy val dottyVersion = settingKey[String]("The version of Dotty to use.")
+
 inThisBuild(List(
   organization := "ch.epfl.lamp",
   scalaVersion := "2.12.4"
 ))
 
-val dottyVersion = dottyLatestNightlyBuild().get
+dottyVersion := sys.env.getOrElse("DOTTY_VERSION", dottyLatestNightlyBuild.get)
 
 lazy val `dotty-community-build` = project
   .in(file("."))
@@ -13,6 +15,6 @@ lazy val `dotty-community-build` = project
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
 
     // BuildInfo plugin settings
-    buildInfoKeys += "dottyVersion" -> dottyVersion,
+    buildInfoKeys += (dottyVersion: BuildInfoKey),
     buildInfoPackage := "dotty.communitybuild"
   )

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eux
+set -o pipefail
+
+RESET="\033[0m"
+GREEN="\033[32m"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)"
+BUILD_DIR="$(mktemp -d)"
+REFERENCE=${DOTTY_REFERENCE:-}
+DOTTY_VERSION=""
+
+if [ ! -z $REFERENCE ]; then
+    echo -e "${GREEN}Building Dotty...${RESET}"
+    pushd "$BUILD_DIR"
+    git clone https://github.com/lampepfl/dotty.git .
+    git fetch origin "$REFERENCE"
+    git checkout -qf FETCH_HEAD
+    git submodule update --init --recursive
+    DOTTY_VERSION=$(sbt -no-colors "dotty-bootstrapped/publishLocal" "show dotty-bootstrapped/version" \
+                      | tail -1 \
+                      | cut -d' ' -f2 \
+                      | tr -d '[:space:]')
+    popd
+
+    rm -rf "$BUILD_DIR"
+    export DOTTY_VERSION
+fi
+
+sbt test


### PR DESCRIPTION
This commit adds a script `run.sh` that builds the reference
specified in `DOTTY_REFERENCE`. This reference is used to determine the
exact commit that must be built. The dotty version that has just been
built is then passed to sbt.

Example:
  - Build a PR:
    ```sh
    DOTTY_REFERENCE="+refs/pull/3306/merge" ./run.sh
    ```
  - Build a tag:
    ```sh
    DOTTY_REFERENCE="0.3.0-RC2" ./run.sh
    ```
  - Build a specific commit:
    ```sh
    DOTTY_REFERENCE="deadbeef" ./run.sh
    ```
  - Build using the latest nightly:
    ```sh
    sbt test
    ```